### PR TITLE
use Module::Install first in Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,6 @@
 BEGIN {
+	use inc::Module::Install;
+
 	my @mip = qw(
 		Module::Install::AuthorTests
 		Module::Install::Repository
@@ -18,7 +20,6 @@ BEGIN {
 	}
 };
 
-use inc::Module::Install;
 name 'Test-Time';
 all_from 'lib/Test/Time.pm';
 


### PR DESCRIPTION
If you don't have Module::Install::Base installed, Makefile.PL dies and installing the module fails, e.g. while executing `carton install`.
This pull-req fixes that issue, following your style as seen in Config::ENV.
