### PR TITLE
Fixing failing MSWIN32 tests for 0.06

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,1 +1,4 @@
 requires 'Test::More';
+
+test_requires 'POSIX';
+

--- a/t/01_base.t
+++ b/t/01_base.t
@@ -1,7 +1,6 @@
 use strict;
 use warnings;
 use Test::More;
-use POSIX qw( tzset );
 use Test::Time time => 1;
 
 is time(), 1, 'initial time taken from use line';
@@ -12,25 +11,9 @@ is time(), 1, 'apparent time unchanged after changes in real time';
 sleep 1;
 is time(), 2, 'apparent time updated after sleep';
 
-$ENV{TZ} = 'Europe/London';
-tzset();
-is scalar( localtime() ), "Thu Jan  1 01:00:02 1970",
-    "localtime() in scalar context correct";
-
-my @localtime = localtime();
-is_deeply \@localtime, [ 2, 0, 1, 1, 0, 70, 4, 0, 0 ],
-    "localtime() in list context correct";
-
-is scalar( localtime(100) ), "Thu Jan  1 01:01:40 1970",
-    "localtime() in scalar context with argument correct";
-
-@localtime = localtime(100);
-is_deeply \@localtime, [ 40, 1, 1, 1, 0, 70, 4, 0, 0 ],
-    "localtime() in list context with argument correct";
-
 Test::Time->unimport();
 
 isnt time(), 1, "removed overwritten time()";
-isnt scalar( localtime() ), "Thu Jan  1 01:00:02 1970", "removed overwritten localtime()";
 
 done_testing;
+

--- a/t/02_localtime.t
+++ b/t/02_localtime.t
@@ -1,0 +1,52 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Time time => 1;
+
+use POSIX qw( tzset );
+
+eval {
+    # might die here with "POSIX::tzset not implemented on this architecture."
+    POSIX::tzset;
+
+    die q!tzset is implemented on this Cygwin. But Windows can't change tz inside script!
+        if $^O eq 'cygwin';
+    die q!tzset is implemented on this Windows. But Windows can't change tz inside script!
+        if $^O eq 'MSWin32';
+};
+if ($@) {
+    plan skip_all => $@;
+}
+
+$ENV{TZ} = 'Europe/London';
+tzset();
+
+is time(), 1, 'initial time taken from use line';
+
+is scalar( localtime() ), "Thu Jan  1 01:00:01 1970",
+    "localtime() in scalar context correct";
+
+CORE::sleep(1);
+is scalar( localtime() ), "Thu Jan  1 01:00:01 1970",
+    "apparent localtime() unchanged after changes in real time";
+
+sleep 1;
+is scalar( localtime() ), "Thu Jan  1 01:00:02 1970",
+    "apparent localtime() updated after sleep";
+
+my @localtime = localtime();
+is_deeply \@localtime, [ 2, 0, 1, 1, 0, 70, 4, 0, 0 ],
+    "localtime() in list context correct";
+
+is scalar( localtime(100) ), "Thu Jan  1 01:01:40 1970",
+    "localtime() in scalar context with argument correct";
+
+@localtime = localtime(100);
+is_deeply \@localtime, [ 40, 1, 1, 1, 0, 70, 4, 0, 0 ],
+    "localtime() in list context with argument correct";
+
+Test::Time->unimport();
+
+isnt scalar( localtime() ), "Thu Jan  1 01:00:02 1970", "removed overwritten localtime()";
+
+done_testing;


### PR DESCRIPTION
Hi,

Thanks for including the previous pull request for localtime().
From the recent cpantesters reports it looks like POSIX::tzset might not work under Windows, so I moved the localtime tests to a new script, and added a SKIP for Windows and Cygwin.

Also I'd forgotten to put the dependency in the cpanfile.

thanks,
Michael