### PR TITLE
make ->import work after ->unimport

### DIFF
--- a/lib/Test/Time.pm
+++ b/lib/Test/Time.pm
@@ -16,6 +16,7 @@ sub in_effect {
 
 sub import {
 	my ($class, %opts) = @_;
+	$in_effect = 1;
 	$time = $opts{time} if defined $opts{time};
 
 	*CORE::GLOBAL::time = sub() {

--- a/t/01_base.t
+++ b/t/01_base.t
@@ -30,7 +30,12 @@ is_deeply \@localtime, [ 40, 1, 1, 1, 0, 70, 4, 0, 0 ],
 
 Test::Time->unimport();
 
-isnt time(), 1, "removed overwritten time()";
+isnt time(), 2, "removed overwritten time()";
 isnt scalar( localtime() ), "Thu Jan  1 01:00:02 1970", "removed overwritten localtime()";
+
+Test::Time->import();
+
+is time(), 2, "re-enabled overwritten time()";
+is scalar( localtime() ), "Thu Jan  1 01:00:02 1970", "re-enabled overwritten localtime()";
 
 done_testing;


### PR DESCRIPTION
previously, there was no way to re-enable the "fake" time routines after they had been disabled by a call to ->unimport