### PR TITLE
tzset is not available on Windows. But it is really not needed.

### DIFF
--- a/t/01_base.t
+++ b/t/01_base.t
@@ -1,7 +1,6 @@
 use strict;
 use warnings;
 use Test::More;
-use POSIX qw( tzset );
 use Test::Time time => 1;
 
 is time(), 1, 'initial time taken from use line';
@@ -12,30 +11,29 @@ is time(), 1, 'apparent time unchanged after changes in real time';
 sleep 1;
 is time(), 2, 'apparent time updated after sleep';
 
-$ENV{TZ} = 'Europe/London';
-tzset();
-is scalar( localtime() ), "Thu Jan  1 01:00:02 1970",
+is scalar( localtime() ), scalar(localtime(2)),
     "localtime() in scalar context correct";
 
 my @localtime = localtime();
-is_deeply \@localtime, [ 2, 0, 1, 1, 0, 70, 4, 0, 0 ],
+is_deeply \@localtime, [ CORE::localtime(2) ],
     "localtime() in list context correct";
 
-is scalar( localtime(100) ), "Thu Jan  1 01:01:40 1970",
+is scalar( localtime(100) ), scalar(localtime(100)),
     "localtime() in scalar context with argument correct";
 
 @localtime = localtime(100);
-is_deeply \@localtime, [ 40, 1, 1, 1, 0, 70, 4, 0, 0 ],
+is_deeply \@localtime, [ CORE::localtime(100) ],
     "localtime() in list context with argument correct";
 
+my $overriden = scalar( localtime() );
 Test::Time->unimport();
 
 isnt time(), 2, "removed overwritten time()";
-isnt scalar( localtime() ), "Thu Jan  1 01:00:02 1970", "removed overwritten localtime()";
+isnt scalar( localtime() ), $overriden, "removed overwritten localtime()";
 
 Test::Time->import();
 
 is time(), 2, "re-enabled overwritten time()";
-is scalar( localtime() ), "Thu Jan  1 01:00:02 1970", "re-enabled overwritten localtime()";
+is scalar( localtime() ), $overriden, "re-enabled overwritten localtime()";
 
 done_testing;


### PR DESCRIPTION
CORE::localtime can be used to provide values for comparison.